### PR TITLE
Issue #24: cohérence des entêtes de licence

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,43 +1,21 @@
 <?php
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Auteur : Guilhem BORGHESI
-//Création : Février 2008
-//
-//borghesi@unistra.fr
-//
-//Ce logiciel est régi par la licence CeCILL-B soumise au droit français et
-//respectant les principes de diffusion des logiciels libres. Vous pouvez
-//utiliser, modifier et/ou redistribuer ce programme sous les conditions
-//de la licence CeCILL-B telle que diffusée par le CEA, le CNRS et l'INRIA
-//sur le site "http://www.cecill.info".
-//
-//Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
-//pris connaissance de la licence CeCILL-B, et que vous en avez accepté les
-//termes. Vous pouvez trouver une copie de la licence dans le fichier LICENCE.
-//
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Author : Guilhem BORGHESI
-//Creation : Feb 2008
-//
-//borghesi@unistra.fr
-//
-//This software is governed by the CeCILL-B license under French law and
-//abiding by the rules of distribution of free software. You can  use,
-//modify and/ or redistribute the software under the terms of the CeCILL-B
-//license as circulated by CEA, CNRS and INRIA at the following URL
-//"http://www.cecill.info".
-//
-//The fact that you are presently reading this means that you have had
-//knowledge of the CeCILL-B license and that you accept its terms. You can
-//find a copy of this license in the file LICENSE.
-//
-//==========================================================================
-
-
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 session_start();
 
@@ -72,7 +50,7 @@ while($dsondage = $sondage->FetchNextObject(false)) {
         // On inclut la routine de suppression
         $date=date('H:i:s d/m/Y');
 
-        if (Utils::remove_sondage($connect, $dsondage->id_sondage) {
+        if (Utils::remove_sondage($connect, $dsondage->id_sondage)) {
            // ecriture des traces dans le fichier de logs
            error_log($date . " SUPPRESSION: $dsondage->id_sondage\t$dsondage->format\t$dsondage->nom_admin\t$dsondage->mail_admin\n", 3, 'logs_studs.txt');
         }

--- a/admin/nettoyage_sondage.php
+++ b/admin/nettoyage_sondage.php
@@ -1,41 +1,21 @@
 <?php
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Auteur : Guilhem BORGHESI
-//Création : Février 2008
-//
-//borghesi@unistra.fr
-//
-//Ce logiciel est régi par la licence CeCILL-B soumise au droit français et
-//respectant les principes de diffusion des logiciels libres. Vous pouvez
-//utiliser, modifier et/ou redistribuer ce programme sous les conditions
-//de la licence CeCILL-B telle que diffusée par le CEA, le CNRS et l'INRIA
-//sur le site "http://www.cecill.info".
-//
-//Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
-//pris connaissance de la licence CeCILL-B, et que vous en avez accepté les
-//termes. Vous pouvez trouver une copie de la licence dans le fichier LICENCE.
-//
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Author : Guilhem BORGHESI
-//Creation : Feb 2008
-//
-//borghesi@unistra.fr
-//
-//This software is governed by the CeCILL-B license under French law and
-//abiding by the rules of distribution of free software. You can  use,
-//modify and/ or redistribute the software under the terms of the CeCILL-B
-//license as circulated by CEA, CNRS and INRIA at the following URL
-//"http://www.cecill.info".
-//
-//The fact that you are presently reading this means that you have had
-//knowledge of the CeCILL-B license and that you accept its terms. You can
-//find a copy of this license in the file LICENSE.
-//
-//==========================================================================
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 include_once __DIR__ . '/../app/inc/init.php';
 

--- a/adminstuds.php
+++ b/adminstuds.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 
@@ -893,7 +894,7 @@ while ($data = $user_studs->FetchNextObject(false)) {
                             <label class="btn btn-default btn-xs" for="n-choice-'.$j.'" title="' . _('Vote "no" for ') . $radio_title[$j] . '">
                                 <span class="glyphicon glyphicon-ban-circle"></span><span class="sr-only">' . _('No') . '</span>
                             </label>
-                        </li>                
+                        </li>
                     </ul>
                 </td>'."\n";
 
@@ -966,7 +967,7 @@ if (!$testligneamodifier=="true") {
                     <label class="btn btn-default btn-xs" for="n-choice-'.$i.'" title="' . _('Vote "no" for ') . $radio_title[$i] . '">
                         <span class="glyphicon glyphicon-ban-circle"></span><span class="sr-only">' . _('No') . '</span>
                     </label>
-                </li>                
+                </li>
             </ul>
         </td>'."\n";
     }

--- a/app/classes/Framadate/Utils.php
+++ b/app/classes/Framadate/Utils.php
@@ -1,22 +1,22 @@
 <?php
-namespace Framadate;
-
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
+namespace Framadate;
 
 class Utils
 {

--- a/app/inc/constants.php.template
+++ b/app/inc/constants.php.template
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 
 // FRAMADATE version

--- a/app/inc/i18n.php
+++ b/app/inc/i18n.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 if (isset($_POST['lang']) && is_string($_POST['lang']) && in_array($_POST['lang'], array_keys($ALLOWED_LANGUAGES)) ) {
     $mlocale = $_POST['lang'] ;

--- a/app/inc/init.php
+++ b/app/inc/init.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 if (ini_get('date.timezone') == '') {
     date_default_timezone_set('Europe/Paris');

--- a/apropos.php
+++ b/apropos.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/bandeaux.php
+++ b/bandeaux.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/choix_autre.php
+++ b/choix_autre.php
@@ -1,21 +1,22 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
- namespace Framadate;
+namespace Framadate;
 
 session_start();
 include_once('creation_sondage.php');

--- a/choix_date.php
+++ b/choix_date.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/contacts.php
+++ b/contacts.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/creation_sondage.php
+++ b/creation_sondage.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/exportcsv.php
+++ b/exportcsv.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/exportics.php
+++ b/exportics.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/exportpdf.php
+++ b/exportpdf.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/index.php
+++ b/index.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/infos_sondage.php
+++ b/infos_sondage.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/maintenance.php
+++ b/maintenance.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 

--- a/scripts/migration_date.php
+++ b/scripts/migration_date.php
@@ -1,41 +1,21 @@
 <?php
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Auteur : Guilhem BORGHESI
-//Création : Février 2008
-//
-//borghesi@unistra.fr
-//
-//Ce logiciel est régi par la licence CeCILL-B soumise au droit français et
-//respectant les principes de diffusion des logiciels libres. Vous pouvez
-//utiliser, modifier et/ou redistribuer ce programme sous les conditions
-//de la licence CeCILL-B telle que diffusée par le CEA, le CNRS et l'INRIA 
-//sur le site "http://www.cecill.info".
-//
-//Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
-//pris connaissance de la licence CeCILL-B, et que vous en avez accepté les
-//termes. Vous pouvez trouver une copie de la licence dans le fichier LICENCE.
-//
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Author : Guilhem BORGHESI
-//Creation : Feb 2008
-//
-//borghesi@unistra.fr
-//
-//This software is governed by the CeCILL-B license under French law and
-//abiding by the rules of distribution of free software. You can  use, 
-//modify and/ or redistribute the software under the terms of the CeCILL-B
-//license as circulated by CEA, CNRS and INRIA at the following URL
-//"http://www.cecill.info". 
-//
-//The fact that you are presently reading this means that you have had
-//knowledge of the CeCILL-B license and that you accept its terms. You can
-//find a copy of this license in the file LICENSE.
-//
-//==========================================================================
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 //ouverture de la connection avec la base SQL
 $connect = pg_connect("host= dbname= user=");
@@ -44,14 +24,14 @@ $sondage=pg_exec($connect, "select * from sondage where format='D' or format='D+
 
 for ($i=0;$i<pg_numrows($sondage);$i++) {
   $dsondage=pg_fetch_object($sondage,$i);
-  
+
   //  print "Pour le sondage ".$dsondage->id_sondage." ";
   $sujets=pg_exec($connect, "select sujet from sujet_studs where id_sondage='$dsondage->id_sondage'");
   $dsujets=pg_fetch_object($sujets,0);
-  
+
   $nouvelledateaffiche="";
   $anciensujethoraires=explode(",",$dsujets->sujet);
-  
+
   for ($j=0;$j<count($anciensujethoraires);$j++) {
     if (strpos('@',$anciensujethoraires[$j]) !== false) {
       $ancientsujet=explode("@",$anciensujethoraires[$j]);
@@ -69,7 +49,7 @@ for ($i=0;$i<pg_numrows($sondage);$i++) {
       }
     }
   }
-  
+
   $nouvelledateaffiche=substr($nouvelledateaffiche,0,-1);
   print $dsujets->sujet.' donne  '.$nouvelledateaffiche.'\n\n';
   //    pg_exec($connect,"update sujet_studs set sujet='$nouvelledateaffiche' where id_sondage='$dsondage->id_sondage'");

--- a/scripts/phpVar2getText.php
+++ b/scripts/phpVar2getText.php
@@ -1,12 +1,30 @@
 <?php
-/*
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
+
+ /*
  raphael.droz@gmail.com, dwtfywwi licence , 2010 :
- 
+
  choppe un fichier $vara="traduction"; dans <lang>.inc
  build un assoc array
  preg_replace les appels wrappés dans gettext() dans le php principal
  generate un .po
- 
+
  (
  echo -e "<?php\n\$l = array (";
  sed -n '/^$.*$/s/^$\([^=]\+\)=.\(.*\).;/"\1"=>\x27\2\x27,/p' lang/en.inc;
@@ -87,7 +105,7 @@ foreach (new DirectoryIterator('.') as $fileInfo) {
   if($fileInfo->isDot()) {
     continue;
   }
-  
+
   $name = $fileInfo->getFilename();
   // process php files
   if(!preg_match('/\.php$/' , $name) || preg_match('/phpVar2getText/', $name)) {
@@ -125,7 +143,7 @@ foreach(array('fr_FR','es_ES','de_DE', 'en_GB') as $i) {
     if($f == 'en') {
       $a .= 'msgid "' . $po_ready_v . '"' . "\n" . 'msgstr "' . $po_ready_v . '"' . "\n\n";
     } else {
-      $a .= 'msgid "' . $po_ready_v . '"' . "\n" . 
+      $a .= 'msgid "' . $po_ready_v . '"' . "\n" .
 	/* ${$k} the key (var name) in the orig (EN) array
 	 to look for as a raw $var while the <lang>.inc is included in the context */
 	'msgstr "' .  stripN(addDQ(${$k})) . '"' . "\n\n";

--- a/scripts/recherche_adresse_admin.php
+++ b/scripts/recherche_adresse_admin.php
@@ -1,41 +1,21 @@
 <?php
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Auteur : Guilhem BORGHESI
-//Création : Février 2008
-//
-//borghesi@unistra.fr
-//
-//Ce logiciel est régi par la licence CeCILL-B soumise au droit français et
-//respectant les principes de diffusion des logiciels libres. Vous pouvez
-//utiliser, modifier et/ou redistribuer ce programme sous les conditions
-//de la licence CeCILL-B telle que diffusée par le CEA, le CNRS et l'INRIA 
-//sur le site "http://www.cecill.info".
-//
-//Le fait que vous puissiez accéder à cet en-tête signifie que vous avez 
-//pris connaissance de la licence CeCILL-B, et que vous en avez accepté les
-//termes. Vous pouvez trouver une copie de la licence dans le fichier LICENCE.
-//
-//==========================================================================
-//
-//Université de Strasbourg - Direction Informatique
-//Author : Guilhem BORGHESI
-//Creation : Feb 2008
-//
-//borghesi@unistra.fr
-//
-//This software is governed by the CeCILL-B license under French law and
-//abiding by the rules of distribution of free software. You can  use, 
-//modify and/ or redistribute the software under the terms of the CeCILL-B
-//license as circulated by CEA, CNRS and INRIA at the following URL
-//"http://www.cecill.info". 
-//
-//The fact that you are presently reading this means that you have had
-//knowledge of the CeCILL-B license and that you accept its terms. You can
-//find a copy of this license in the file LICENSE.
-//
-//==========================================================================
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
+ * is not distributed with this file, you can obtain one at
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
+ *
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
+ *
+ * =============================
+ *
+ * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
+ * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
+ *
+ * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
+ */
 
 //ouverture de la connection avec la base SQL
 $connect = pg_connect("host= dbname= user=");

--- a/studs.php
+++ b/studs.php
@@ -1,19 +1,20 @@
 <?php
-/* This software is governed by the CeCILL-B license. If a copy of this license
+/**
+ * This software is governed by the CeCILL-B license. If a copy of this license
  * is not distributed with this file, you can obtain one at
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt
  *
- * Authors of STUdS (initial project) : Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
- * Authors of OpenSondage : Framasoft (https://github.com/framasoft)
+ * Authors of STUdS (initial project): Guilhem BORGHESI (borghesi@unistra.fr) and Raphaël DROZ
+ * Authors of Framadate/OpenSondate: Framasoft (https://github.com/framasoft)
  *
  * =============================
  *
  * Ce logiciel est régi par la licence CeCILL-B. Si une copie de cette licence
  * ne se trouve pas avec ce fichier vous pouvez l'obtenir sur
- * http://www.cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
+ * http://www.cecill.info/licences/Licence_CeCILL-B_V1-fr.txt
  *
  * Auteurs de STUdS (projet initial) : Guilhem BORGHESI (borghesi@unistra.fr) et Raphaël DROZ
- * Auteurs d'OpenSondage : Framasoft (https://github.com/framasoft)
+ * Auteurs de Framadate/OpenSondage : Framasoft (https://github.com/framasoft)
  */
 namespace Framadate;
 
@@ -488,7 +489,7 @@ while ($data = $user_studs->FetchNextObject(false)) {
                             <label class="btn btn-default btn-xs" for="n-choice-'.$k.'" title="' . _('Vote "no" for ') . $radio_title[$k] . '">
                                 <span class="glyphicon glyphicon-ban-circle"></span><span class="sr-only">' . _('No') . '</span>
                             </label>
-                        </li>                
+                        </li>
                     </ul>
                 </td>'."\n";
 
@@ -559,7 +560,7 @@ if (( !(USE_REMOTE_USER && isset($_SERVER['REMOTE_USER'])) || !$user_mod) && $li
                     <label class="btn btn-default btn-xs" for="n-choice-'.$i.'" title="' . _('Vote "no" for ') . $radio_title[$i] . '">
                         <span class="glyphicon glyphicon-ban-circle"></span><span class="sr-only">' . _('No') . '</span>
                     </label>
-                </li>                
+                </li>
             </ul>
         </td>'."\n";
     }


### PR DESCRIPTION
- utilisation de /\* */ comme syntaxe de commentaire de licence partout (pour pouvoir plier le code)
- mise à jour des liens vers les licences qui pointaient vers CECILL-A alors que c'est du CECILL-B
- correction d'un erreur de syntaxe php dans un fichier (parenthèse manquante)
- Ajout du bloc de licence sur les fichiers php qui ne l'avaient pas
