### PR TITLE
use require instead of include* functions

### DIFF
--- a/app/inc/init.php
+++ b/app/inc/init.php
@@ -21,10 +21,10 @@ if (ini_get('date.timezone') == '') {
     date_default_timezone_set('Europe/Paris');
 }
 // Autoloading of dependencies with Composer
-require_once __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
-include_once __DIR__ . '/constants.php';
-include_once __DIR__ . '/i18n.php';
+require __DIR__ . '/constants.php';
+require __DIR__ . '/i18n.php';
 
 $connect = NewADOConnection(BASE_TYPE);
 $connect->Connect(SERVEURBASE, USERBASE, USERPASSWD, BASE);


### PR DESCRIPTION
Hi,

For me, the script must be stopped when the constants.php file is missing.