### PR TITLE
fix overflowing table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -242,6 +242,7 @@ caption {
 #tableContainer {
     overflow-x:auto;
     margin:5px auto;
+    position: relative;
 }
 
 table.results {


### PR DESCRIPTION
If the table exceeds the screen width, the page gets a scroll on the x-axis. This occurs even if a parent container has 'overflow-auto' set. Adding 'position: relative' to the tableContainer resolves this issue. Not only is the scrollbar unappealing, but it also diminishes the user experience, as every date selection causes the viewport to move to the right.
Before (scrollbar on the bottom of the page):
![image](https://github.com/framasoft/framadate/assets/23173973/3c76e9bf-8400-4fef-ae19-5e065c6f8c5b)
After:
![image](https://github.com/framasoft/framadate/assets/23173973/45a21c7c-de75-4348-8b2d-44fa7f0197ec)
